### PR TITLE
Option to skip first line in rec and 2 options to set custom bg and text color for export

### DIFF
--- a/cmd/termsvg/export/export.go
+++ b/cmd/termsvg/export/export.go
@@ -12,9 +12,11 @@ import (
 )
 
 type Cmd struct {
-	File   string `arg:"" type:"existingfile" help:"asciicast file to export"`
-	Output string `optional:"" short:"o" type:"path" help:"where to save the file. Defaults to <input_file>.svg"`
-	Mini   bool   `name:"minify" optional:"" short:"m" help:"minify output file. May be slower"`
+	File            string `arg:"" type:"existingfile" help:"asciicast file to export"`
+	Output          string `optional:"" short:"o" type:"path" help:"where to save the file. Defaults to <input_file>.svg"`
+	Mini            bool   `name:"minify" optional:"" short:"m" help:"minify output file. May be slower"`
+	BackgroundColor string `optional:"" short:"b" help:"background color in hexadecimal format (e.g. #FFFFFF)"`
+	TextColor       string `optional:"" short:"t" help:"text color in hexadecimal format (e.g. #000000)"`
 }
 
 func (cmd *Cmd) Run() error {
@@ -23,7 +25,7 @@ func (cmd *Cmd) Run() error {
 		output = cmd.File + ".svg"
 	}
 
-	err := export(cmd.File, output, cmd.Mini)
+	err := export(cmd.File, output, cmd.Mini, cmd.BackgroundColor, cmd.TextColor)
 	if err != nil {
 		return err
 	}
@@ -33,7 +35,7 @@ func (cmd *Cmd) Run() error {
 	return nil
 }
 
-func export(input, output string, mini bool) error {
+func export(input, output string, mini bool, bgColor, textColor string) error {
 	inputFile, err := os.ReadFile(input)
 	if err != nil {
 		return err
@@ -52,7 +54,7 @@ func export(input, output string, mini bool) error {
 
 	if mini {
 		out := new(bytes.Buffer)
-		svg.Export(*cast, out)
+		svg.Export(*cast, out, bgColor, textColor)
 
 		m := minify.New()
 		m.AddFunc("image/svg+xml", msvg.Minify)
@@ -67,7 +69,7 @@ func export(input, output string, mini bool) error {
 			return err
 		}
 	} else {
-		svg.Export(*cast, outputFile)
+		svg.Export(*cast, outputFile, bgColor, textColor)
 	}
 
 	return nil

--- a/cmd/termsvg/rec/rec.go
+++ b/cmd/termsvg/rec/rec.go
@@ -27,6 +27,10 @@ func (cmd *Cmd) Run() error {
 	log.Info().Str("output", cmd.File).Msg("recording asciicast.")
 	log.Info().Msg("exit the opened program when you're done.")
 
+	if cmd.SkipFirstLine {
+		log.Warn().Msg("Skipping the first line of recording.")
+	}
+
 	err := rec(cmd.File, cmd.Command, cmd.SkipFirstLine)
 	if err != nil {
 		return err

--- a/cmd/termsvg/rec/rec.go
+++ b/cmd/termsvg/rec/rec.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -15,8 +16,9 @@ import (
 )
 
 type Cmd struct {
-	File    string `arg:"" type:"path" help:"filename/path to save the recording to"`
-	Command string `short:"c" optional:"" env:"SHELL" help:"Specify command to record, defaults to $SHELL"`
+	File          string `arg:"" type:"path" help:"filename/path to save the recording to"`
+	Command       string `short:"c" optional:"" env:"SHELL" help:"Specify command to record, defaults to $SHELL"`
+	SkipFirstLine bool   `short:"s" help:"Skip the first line of recording"`
 }
 
 const readSize = 1024
@@ -25,7 +27,7 @@ func (cmd *Cmd) Run() error {
 	log.Info().Str("output", cmd.File).Msg("recording asciicast.")
 	log.Info().Msg("exit the opened program when you're done.")
 
-	err := rec(cmd.File, cmd.Command)
+	err := rec(cmd.File, cmd.Command, cmd.SkipFirstLine)
 	if err != nil {
 		return err
 	}
@@ -36,8 +38,8 @@ func (cmd *Cmd) Run() error {
 	return nil
 }
 
-func rec(file, command string) error {
-	events, err := run(command)
+func rec(file, command string, skipFirstLine bool) error {
+	events, err := run(command, skipFirstLine)
 	if err != nil {
 		return err
 	}
@@ -68,8 +70,8 @@ func rec(file, command string) error {
 	return nil
 }
 
-//nolint
-func run(command string) ([]asciicast.Event, error) {
+// nolint
+func run(command string, skipFirstLine bool) ([]asciicast.Event, error) {
 	// Create arbitrary command.
 	c := exec.Command("sh", "-c", command)
 	// Start the command with a pty.
@@ -112,6 +114,8 @@ func run(command string) ([]asciicast.Event, error) {
 	p := make([]byte, readSize)
 	baseTime := time.Now().UnixMicro()
 
+	startTriggered := false
+
 	for {
 		n, err := ptmx.Read(p)
 		event := asciicast.Event{
@@ -130,6 +134,19 @@ func run(command string) ([]asciicast.Event, error) {
 		}
 
 		os.Stdout.Write(p[:n])
+
+		// Skip the first line
+		if skipFirstLine {
+			if !startTriggered {
+				if strings.Contains(string(p[:n]), "\n") {
+					startTriggered = true
+					baseTime = time.Now().UnixMicro()
+					continue
+				} else {
+					continue
+				}
+			}
+		}
 
 		events = append(events, event)
 	}

--- a/internal/svg/svg_test.go
+++ b/internal/svg/svg_test.go
@@ -20,7 +20,8 @@ func TestExport(t *testing.T) {
 
 	var output bytes.Buffer
 
-	svg.Export(*cast, &output)
+	// Pass empty override bg and text colors
+	svg.Export(*cast, &output, "", "")
 
 	g := goldie.New(t)
 	g.Assert(t, "TestExportOutput", output.Bytes())
@@ -37,6 +38,7 @@ func BenchmarkExport(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var output bytes.Buffer
 
-		svg.Export(*cast, &output)
+		// Pass empty override bg and text colors
+		svg.Export(*cast, &output, "", "")
 	}
 }


### PR DESCRIPTION
Hi,
This pull request has 2 feature additions.
1. Added a parameter to rec command
   -s, --skip-first-line"
This allows to skip the first line of recording
Purpose of this is to allow user to set custom environment variables or change PS1 terminal variable before recording.
Typical usage would be to set api key variables for the demo and to change usr@host PS1 variable.
First line delimiter is set to \n and recording starts after [enter] is pressed
Example:
export API_KEY=test; PS1="user@host:"; some other command [enter]
* Recording starts

2. Added 2 parameters to export to allow setting custom background and text color for exported svg.
  -b, --background-color=STRING    background color in hexadecimal format (e.g. #FFFFFF)
  -t, --text-color=STRING          text color in hexadecimal format (e.g. #000000)
This one is self explanatory, i find it very usefull to be able to customize what the svg will look like.

Thanks